### PR TITLE
Initialize Z[2,3,4]_DIR_PIN and Z[2,3,4]_STEP_PIN

### DIFF
--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -1016,6 +1016,11 @@ void Stepper::init() {
     #if ENABLED(Z_DUAL_STEPPER_DRIVERS) && HAS_Z2_DIR
       Z2_DIR_INIT;
     #endif
+    #if ENABLED(Z_QUAD_STEPPER_DRIVERS)
+      Z2_DIR_INIT;
+      Z3_DIR_INIT;
+      Z4_DIR_INIT;
+    #endif
   #endif
   #if HAS_E0_DIR
     E0_DIR_INIT;
@@ -1122,6 +1127,14 @@ void Stepper::init() {
     #if ENABLED(Z_DUAL_STEPPER_DRIVERS)
       Z2_STEP_INIT;
       Z2_STEP_WRITE(INVERT_Z_STEP_PIN);
+    #endif
+    #if ENABLED(Z_QUAD_STEPPER_DRIVERS)
+      Z2_STEP_INIT;
+      Z2_STEP_WRITE(INVERT_Z_STEP_PIN);
+      Z3_STEP_INIT;
+      Z3_STEP_WRITE(INVERT_Z_STEP_PIN);
+      Z4_STEP_INIT;
+      Z4_STEP_WRITE(INVERT_Z_STEP_PIN);
     #endif
     AXIS_INIT(Z, Z);
   #endif


### PR DESCRIPTION
It looks like without explicit init 2560 leaves low-pass filter attached to the pins (probably true for analog pins only, haven't checked). As a result, edges of the output pulses are pretty much destroyed. Some stepper drivers go crazy because of that...

This change initializes Z2,Z3,Z4 DIR and STEP pins.