### PR TITLE
Alternative gantry leveling code

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6115,6 +6115,7 @@ void home_all_axes() { gcode_G28(true); }
 
     float z_mea[4] = { 0.0 };
     float z_corr[4] = { 0.0 };
+    float center;
 
     SYNC_PLAN_POSITION_KINEMATIC();
 
@@ -6123,10 +6124,14 @@ void home_all_axes() { gcode_G28(true); }
     z_mea[0] = probe_pt(LEFT_LEVELING_POSITION, FRONT_LEVELING_POSITION, false, 1);
     z_mea[1] = probe_pt(LEFT_LEVELING_POSITION, BACK_LEVELING_POSITION, false, 1);
 
-    z_corr[0] = z_mea[0] + (z_mea[0] - z_mea[2]);
-    z_corr[2] = z_mea[2] + (z_mea[2] - z_mea[0]);
-    z_corr[1] = z_mea[1] + (z_mea[1] - z_mea[3]);
-    z_corr[3] = z_mea[3] + (z_mea[3] - z_mea[1]);
+    center = (z_mea[0] + z_mea[1] + z_mea[2] + z_mea[3]) / 4;
+
+    // This assumes that measuring points are at 1/3s between z belts.
+    // So to achieve needed adjustment at measuring point, corresponding z needs to move x3
+    z_corr[0] = (z_mea[0] - center) * 3;
+    z_corr[2] = (z_mea[2] - center) * 3;
+    z_corr[1] = (z_mea[1] - center) * 3;
+    z_corr[3] = (z_mea[3] - center) * 3;
 
     SERIAL_PROTOCOLLNPGM("Measured:");
     SERIAL_PROTOCOL_F(z_mea[1], 3);


### PR DESCRIPTION
On my build gantry is sagging quite a bit at the A/B drive side so it's easy to see overcorrection.
I think this approach works a bit better... Even with frame geometry not perfectly defined it gets within 0.1mm  or so on second try. Have a look...