### PR TITLE
Alternative leveling position math

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -316,22 +316,28 @@
 #define NOZZLE_OFFSET_SWITCH
 
 #if ENABLED(Z_QUAD_STEPPER_DRIVERS)
-
   // Printer geometry
   // --------------------------------
-  // Distance between Z acruator points
-  #define X_SPAN 370.0 // Normally the frame side extrusion lenght    
-  #define Y_SPAN (X_SPAN - 45)
 
-  // Bed 0,0 offset from front left actuator
-  #define X_BED_OFFSET ((X_SPAN - X_BED_SIZE) / 2 )
-  #define Y_BED_OFFSET 10.0
+  // Side extrusion lengths: 370 for 250mm build, 420 for 300mm build, 470 for 350mm build
+  #define X_SPAN 370.0
+  #define Y_SPAN X_SPAN  // Same as X_SPAN for square frame
 
-  // Leveling probe area
-  #define FRONT_LEVELING_POSITION ((Y_SPAN / 3) - Y_BED_OFFSET)
-  #define BACK_LEVELING_POSITION ((Y_SPAN / 3) * 2 - Y_BED_OFFSET)
-  #define LEFT_LEVELING_POSITION ((X_SPAN / 3) - X_BED_OFFSET)
-  #define RIGHT_LEVELING_POSITION ((X_SPAN / 3) * 2 - X_BED_OFFSET)
+  // Position of Z actuator relative to corresponding corner
+  #define X_INSET 0.0
+  #define Y_INSET 22.5
+
+  // Position of induction sensor from right back corner when homed in (defined by endstops geometry)
+  #define SENSOR_OFFSET_RIGHT 62.0
+  #define SENSOR_OFFSET_BACK  65.0
+
+  #define X_THIRD ((X_SPAN - X_INSET * 2) / 3)
+  #define Y_THIRD ((Y_SPAN - Y_INSET * 2) / 3)
+
+  #define RIGHT_LEVELING_POSITION (X_BED_SIZE + SENSOR_OFFSET_RIGHT - X_INSET - X_THIRD)
+  #define BACK_LEVELING_POSITION  (Y_BED_SIZE + SENSOR_OFFSET_BACK  - Y_INSET - Y_THIRD)
+  #define LEFT_LEVELING_POSITION  (RIGHT_LEVELING_POSITION - X_THIRD)
+  #define FRONT_LEVELING_POSITION (BACK_LEVELING_POSITION  - Y_THIRD)
 
 #endif
 


### PR DESCRIPTION
This change shifts reference point for leveling points calculation to home.

As a result, this de-couples bed size/offset from position calculation, people with not-exact-spec beds may have a little easier time configuring their machines... In other words, even if bed size is configured wrong, this produces good leveling point coords.

Sensor offsets are measured on my machine and could be off by a mm or two cuz of the switches I used. The difference should have very little effect on accuracy.

Have a look.