### PR TITLE
Fix typo in möbius steps

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -529,7 +529,7 @@
  * Override with M92
  *                                      X, Y, Z, E0 [, E1[, E2[, E3[, E4]]]]
  */
-#define DEFAULT_AXIS_STEPS_PER_UNIT   { 80, 80, 160, 385 }
+#define DEFAULT_AXIS_STEPS_PER_UNIT   { 80, 80, 160, 305 }
 
 /**
  * Default Max Feed Rate (mm/s)


### PR DESCRIPTION
1.8deg stepper with 20t/40t reduction and MK8 gear needs ~305 steps/mm.